### PR TITLE
added format correction to redirect handler

### DIFF
--- a/backend/functions/redirect.js
+++ b/backend/functions/redirect.js
@@ -19,10 +19,18 @@ export const handler = async (event) => {
 
     if (item.Items) {
       // redirect to the short url
+      var original_url = item.Items[0].og_url;
+      if (
+        original_url.slice(0, 8) != "https://" &&
+        original_url.slice(0, 7) != "http://"
+      ) {
+        //Prepends scheme to the redirect url if it is absent in the database item
+        original_url = "https://" + original_url;
+      }
       return {
         statusCode: 302,
         headers: {
-          Location: item.Items[0].og_url,
+          Location: original_url,
         },
       };
     }


### PR DESCRIPTION
I noticed that if a user tries to shorten a url without including the scheme, such as "github.com", the redirect handler throws an error.  By conditionally prepending "https://" the error is prevented and redirect always succeeds. 